### PR TITLE
Fix #3 DESCRIPTION info for citation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,38 +1,34 @@
 Package: aggreCAT
 Title: Mathematically Aggregating Expert Judgments
 Version: 0.0.0.9002
-Authors@R: c(person(given = "Aaron", 
+Authors@R: c(person(given = "Elliot", 
+                    family = "Gould", 
+                    role = "aut", 
+                    comment = structure("0000-0002-6585-538X", .Names = "ORCID")),
+                    person(given = "Charles T.",
+                    family = "Gray",
+                    role = c("aut"),
+                    comment = structure("00000-0002-9978-011X", .Names = "ORCID")),
+                    person(given = "Aaron", 
                     family = "Willcox", 
                     role = "aut",
                     email = " aaron@willcox.io",
                     comment = structure("0000-0003-2536-2596", .Names = "ORCID")),
-                person(given = "Charles T.",
-                    family = "Gray",
-                    role = c("aut"),
-                    comment = structure("00000-0002-9978-011X", .Names = "ORCID")),
-                person(given = "Elliot", 
-                    family = "Gould", 
+                    person(given = "Rose", 
+                    family = "E. O'Dea", 
                     role = "aut", 
-                    comment = structure("0000-0002-6585-538X", .Names = "ORCID")),
-                person(given = "David", 
+                    comment = structure("0000-0001-8177-5075", .Names = "ORCID")),
+                    person(given = "Rebecca", 
+                        family = "Groenewegen", 
+                        role = c("aut"),
+                        comment = structure("https://orcid.org/0000-0001-9177-8536", .Names = "ORCID")
+                        ),
+                        person(given = "David", 
                         family = "Wilkinson", 
                         role = c("aut", "cre"),
                         email = "david.wilkinson.research@gmail.com",
                         comment = structure("0000-0002-9560-6499", .Names = "ORCID")
-                        ),
-                person(given = "Anca", 
-                    family = "Hanea", 
-                    role = "aut", 
-                    comment = structure("0000-0003-3870-5949", .Names = "ORCID")),
-                person(given = "Bonnie", 
-                    family = "Wintle", 
-                    role = "aut", 
-                    comment = structure("0000-0003-0236-6906", .Names = "ORCID")),
-                person(given = "Rose", 
-                    family = "E. O'Dea", 
-                    role = "aut", 
-                    comment = structure("0000-0001-8177-5075", .Names = "ORCID"))
-           )
+                        ))
 Description: Aggregator methods for confidence scores.
 URL: https://replicats.research.unimelb.edu.au/
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,6 +88,7 @@ Imports:
     insight
 Remotes: 
     softloud/neet
+Date: 2022-10-12
 VignetteBuilder: R.rsp
 RdMacros: mathjaxr
 Config/testthat/parallel: true


### PR DESCRIPTION
- Reorder author names in DESCRIPTION to align with order in manuscript
- Add `Date:` tag to DESCRIPTION so that `citation()` does not throw warning, #3