### PR TITLE
fix: correct BayesianWAgg docs — posterior mean, not median

### DIFF
--- a/R/BayesianWAgg.R
+++ b/R/BayesianWAgg.R
@@ -39,7 +39,7 @@
 #'
 #' The uninformative priors for specifying this Bayesian model are
 #' \mjeqn{\mu_c \sim N(0,\ 3)}{ascii}, \mjeqn{\sigma_i \sim U(0,\ 10)}{ascii} and
-#' \mjeqn{\sigma_c \sim U(0,\ 10)}{ascii}. After obtaining the median of the posterior
+#' \mjeqn{\sigma_c \sim U(0,\ 10)}{ascii}. After obtaining the mean of the posterior
 #' distribution of \mjeqn{\mu_c}{ascii}, we can back transform to obtain
 #' \mjeqn{\hat{p}_c}{ascii}:
 #'

--- a/man/BayesianWAgg.Rd
+++ b/man/BayesianWAgg.Rd
@@ -73,7 +73,7 @@ deviation of the estimated probability of replication for claim \mjeqn{c}{ascii}
 
 The uninformative priors for specifying this Bayesian model are
 \mjeqn{\mu_c \sim N(0,\ 3)}{ascii}, \mjeqn{\sigma_i \sim U(0,\ 10)}{ascii} and
-\mjeqn{\sigma_c \sim U(0,\ 10)}{ascii}. After obtaining the median of the posterior
+\mjeqn{\sigma_c \sim U(0,\ 10)}{ascii}. After obtaining the mean of the posterior
 distribution of \mjeqn{\mu_c}{ascii}, we can back transform to obtain
 \mjeqn{\hat{p}_c}{ascii}:
 


### PR DESCRIPTION
Fixes #80

## Problem
The roxygen documentation for `BayesianWAgg()` on line 42 of `R/BayesianWAgg.R` states:

> After obtaining the **median** of the posterior distribution of μ_c

But the implementation at line 417 selects the **mean** column from the JAGS summary output:

```r
dplyr::select(mean)
```

JAGS's `` provides both mean and median (`50%`); the code uses `mean`.

## Fix
Changed "median" → "mean" in:
- `R/BayesianWAgg.R` (roxygen source, line 42)
- `man/BayesianWAgg.Rd` (generated Rd, line 76)

## Validation
- Verified the code path: `CSsamples` → `dplyr::select(mean)` → `dplyr::rename(aggregated_judgement = mean)`
- No other references to "median" remain in the function documentation
- Single-word change, no behavioral impact